### PR TITLE
Bump rand dependency to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "AGPL-3.0"
 documentation = "https://docs.rs/eff-wordlist/"
 
 [dependencies]
-rand = "0.6"
+rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,7 @@ pub mod large {
     /// let word = eff_wordlist::large::random_word();
     /// ```
     pub fn random_word() -> &'static str {
-        let mut rng = OsRng::new().expect("Not able to operate without random source.");
-        LIST.choose(&mut rng).unwrap().1
+        LIST.choose(&mut OsRng).unwrap().1
     }
 
 }
@@ -72,8 +71,7 @@ pub mod short {
     /// let word = eff_wordlist::short::random_word();
     /// ```
     pub fn random_word() -> &'static str {
-        let mut rng = OsRng::new().expect("Not able to operate without random source.");
-        LIST.choose(&mut rng).unwrap().1
+        LIST.choose(&mut OsRng).unwrap().1
     }
 
 }


### PR DESCRIPTION
The `OsRng` struct changed in 0.8 and no longer needs to be constructed explicitly.